### PR TITLE
feat(example): add example page with prose typography, responsive grid, and reusable form field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
+                "@tailwindcss/typography": "^0.5.16",
                 "@tailwindcss/vite": "^4.0.0",
                 "alpinejs": "^3.4.2",
                 "autoprefixer": "^10.4.2",
@@ -1261,6 +1262,36 @@
             ],
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@tailwindcss/typography": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+            "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.castarray": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "postcss-selector-parser": "6.0.10"
+            },
+            "peerDependencies": {
+                "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+            }
+        },
+        "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@tailwindcss/vite": {
@@ -2639,6 +2670,27 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.castarray": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
+        "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.0.0",
         "alpinejs": "^3.4.2",
         "autoprefixer": "^10.4.2",

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -1,0 +1,18 @@
+@props(['label', 'name', 'type' => 'text'])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-sm font-medium text-gray-700 mb-1">
+        {{ $label }}
+    </label>
+    <input
+        type="{{ $type }}"
+        name="{{ $name }}"
+        id="{{ $name }}"
+        {{ $attributes->merge([
+            'class' => 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm'
+        ]) }}
+    >
+    @error($name)
+        <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/example.blade.php
+++ b/resources/views/example.blade.php
@@ -1,0 +1,31 @@
+<x-app-layout>
+    <div class="prose max-w-none">
+        <h1>Example Page</h1>
+        <p>
+            This page demonstrates the <code>prose</code> typography styles and a responsive card grid.
+            Resize your browser to see the layout adapt from mobile to desktop.
+        </p>
+    </div>
+
+    <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        @foreach (range(1, 6) as $i)
+            <div class="bg-white rounded-lg shadow p-4">
+                <h2 class="text-lg font-semibold mb-2">Card {{ $i }}</h2>
+                <p class="text-sm text-gray-600">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+                </p>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mt-8">
+        <form action="#" method="POST">
+            @csrf
+            <x-form.field label="Example Input" name="example" placeholder="Type something..." />
+            <button type="submit"
+                    class="mt-2 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+                Submit
+            </button>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('example')" :active="request()->routeIs('example')">
+                        {{ __('Example') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +72,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('example')" :active="request()->routeIs('example')">
+                {{ __('Example') }}
             </x-responsive-nav-link>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,4 +17,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+Route::get('/example', function () {
+    return view('example');
+})->name('example');
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### Summary
- Added /example route and Blade view.
- Demonstrates @tailwindcss/typography plugin with `prose` styles.
- Includes responsive card grid (1 col mobile, 2 cols sm, 3 cols lg).
- Uses <x-form.field> component for consistent form styling.
- Linked Example page in both desktop and mobile nav.

### Purpose
Provides a visual testbed for layout, typography, and form components before starting CRUD features.

### Testing
1. Pull branch and run `npm install` (if not already done).
2. Run `npm run dev` and visit http://localhost/example.
3. Confirm:
   - Typography styles applied.
   - Grid is responsive.
   - Form field matches Breeze auth forms.
   - Nav link works on mobile and desktop.

### Screenshots
<img width="1915" height="683" alt="image" src="https://github.com/user-attachments/assets/f6c0eedd-6c86-4b71-b387-f8aeced55b2c" />
<img width="809" height="796" alt="image" src="https://github.com/user-attachments/assets/e5ac5eab-b0e4-4605-833f-225242d8f879" />
<img width="496" height="1028" alt="image" src="https://github.com/user-attachments/assets/f7407257-2123-45b0-aecf-269b9145c8de" />
