### PR TITLE
feat(example): add example page with prose typography, responsive grid, and reusable form field

### DIFF
--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -1,0 +1,18 @@
+@props(['label', 'name', 'type' => 'text'])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-sm font-medium text-gray-700 mb-1">
+        {{ $label }}
+    </label>
+    <input
+        type="{{ $type }}"
+        name="{{ $name }}"
+        id="{{ $name }}"
+        {{ $attributes->merge([
+            'class' => 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm'
+        ]) }}
+    >
+    @error($name)
+        <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/example.blade.php
+++ b/resources/views/example.blade.php
@@ -1,0 +1,31 @@
+<x-app-layout>
+    <div class="prose max-w-none">
+        <h1>Example Page</h1>
+        <p>
+            This page demonstrates the <code>prose</code> typography styles and a responsive card grid.
+            Resize your browser to see the layout adapt from mobile to desktop.
+        </p>
+    </div>
+
+    <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        @foreach (range(1, 6) as $i)
+            <div class="bg-white rounded-lg shadow p-4">
+                <h2 class="text-lg font-semibold mb-2">Card {{ $i }}</h2>
+                <p class="text-sm text-gray-600">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
+                </p>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mt-8">
+        <form action="#" method="POST">
+            @csrf
+            <x-form.field label="Example Input" name="example" placeholder="Type something..." />
+            <button type="submit"
+                    class="mt-2 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+                Submit
+            </button>
+        </form>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,9 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('example')" :active="request()->routeIs('example')">
+                        {{ __('Example') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -69,6 +72,9 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('example')" :active="request()->routeIs('example')">
+                {{ __('Example') }}
             </x-responsive-nav-link>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,4 +17,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+Route::get('/example', function () {
+    return view('example');
+})->name('example');
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
### Summary
- Added /example route and Blade view.
- Demonstrates @tailwindcss/typography plugin with `prose` styles.
- Includes responsive card grid (1 col mobile, 2 cols sm, 3 cols lg).
- Uses <x-form.field> component for consistent form styling.
- Linked Example page in both desktop and mobile nav.

### Purpose
Provides a visual testbed for layout, typography, and form components before starting CRUD features.

### Testing
1. Pull branch and run `npm install` (if not already done).
2. Run `npm run dev` and visit http://localhost/example.
3. Confirm:
   - Typography styles applied.
   - Grid is responsive.
   - Form field matches Breeze auth forms.
   - Nav link works on mobile and desktop.
